### PR TITLE
Remove the tests directory from the build files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 setup(
     name="adagio",
     version=__version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests', )),
     description="The Dag IO Framework for Fugue projects",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Background

The top-level `tests` directory is included in the build files. When I install the library, there's `tests` directory in the `site-packages` as well as `adagio`, and `adagio_version`. It may prevent the users from importing their `tests` directory. 

<img width="252" alt="スクリーンショット 2024-02-28 19 03 12" src="https://github.com/fugue-project/adagio/assets/4068610/b7051e37-1883-4ede-8016-72e6d7fd8397">

# Changes

I added the `exclude` option to `find_packages` to exclude the test directory